### PR TITLE
Customize mitake gem for legacy Rails project

### DIFF
--- a/lib/mitake/balance.rb
+++ b/lib/mitake/balance.rb
@@ -16,7 +16,7 @@ module Mitake
       #
       # @since 0.1.0
       def amount
-        execute&.first&.amount
+        execute && execute.first && execute.first.amount
       end
     end
 

--- a/lib/mitake/message.rb
+++ b/lib/mitake/message.rb
@@ -64,7 +64,7 @@ module Mitake
       return self if sent?
 
       self.class.execute(params) do |items|
-        attrs = items&.first&.slice(*self.class.attribute_names)
+        attrs = items.first
         assign_attributes(attrs)
       end
 
@@ -108,8 +108,8 @@ module Mitake
       {
         clientid: @source_id,
         smbody: @body,
-        dlvtime: @schedule_at&.strftime('%Y%m%d%H%M%S'),
-        vldtime: @expired_at&.strftime('%Y%m%d%H%M%S'),
+        dlvtime: @schedule_at && @schedule_at.strftime('%Y%m%d%H%M%S'),
+        vldtime: @expired_at && @expired_at.strftime('%Y%m%d%H%M%S'),
         dstaddr: @recipient.phone_number,
         destname: @recipient.name,
         response: @webhook_url


### PR DESCRIPTION
Get rid of the uses of
 * ruby 2.3 `&.` syntax, and
 * `Hash::slice` from ActiveSupport::CoreExtensions